### PR TITLE
fixed transmission data mount according to docs

### DIFF
--- a/dmc/compose/docker-compose.yml
+++ b/dmc/compose/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       - TZ={TIMEZONE}
     volumes:
       - ${SERVICES_DIR}/transmission:/config
-      - ${DATA_DIR}/downloads:/data/downloads
+      - ${DATA_DIR}/downloads:/downloads
     ports:
       - 51413:51413 # Torrent port TCP
       - 51413:51413/udp # Torrent port UDP


### PR DESCRIPTION
There was a problem with mounting transmission data dir,  apparently they changed mounting point, followed [official doc](https://hub.docker.com/r/linuxserver/transmission) to fix the path.
 